### PR TITLE
Upgrade Log4J 2.14.1 to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@ under the License.
 		<scala.binary.version>2.12</scala.binary.version>
 		<flink.version>1.14.0</flink.version>
 		<hadoop.version>2.8.3</hadoop.version>
-		<log4j.version>2.14.1</log4j.version>
+		<log4j.version>2.17.0</log4j.version>
 		<junit.version>4.13.2</junit.version>
 	</properties>
 


### PR DESCRIPTION
Motivation:

Log4J upgrade to address a security risk CVE-2021-45105

Modifications:

Upgrade from 2.14.1 to 2.17.0

Result:

Using a safer Log4J version